### PR TITLE
Add branch protection to main branch

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,29 @@
+name: Branch Protection
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  branch-protection:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-setup branch protection
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'main',
+              required_status_checks: null,
+              enforce_admins: true,
+              required_pull_request_reviews: {
+                required_approving_review_count: 1,
+                dismiss_stale_reviews: true,
+                require_code_owner_reviews: false
+              },
+              restrictions: null
+            })


### PR DESCRIPTION
This pull request adds branch protection rules for the main branch. Once merged, the main branch will require at least one approval before merging any changes.

Key settings:
- Requires at least 1 approval before merging
- Dismisses stale reviews when new commits are pushed
- Enforces branch protection for administrators

This helps maintain code quality and ensures that changes are reviewed before being merged into the main branch. Adding this protection aligns with the security practices implemented across the other repositories in the CogentEcho.ai ecosystem.